### PR TITLE
Add generic debug interface for STM32

### DIFF
--- a/PN532/PN532_debug.c
+++ b/PN532/PN532_debug.c
@@ -1,0 +1,4 @@
+#include "PN532_debug.h"
+#include <stdio.h>
+
+pn532_debug_printf_t pn532_debug_printf = printf;

--- a/PN532/PN532_debug.h
+++ b/PN532/PN532_debug.h
@@ -1,20 +1,39 @@
 #ifndef __DEBUG_H__
 #define __DEBUG_H__
 
+
 //#define DEBUG
 
-#include "Arduino.h"
+#include <stdio.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int (*pn532_debug_printf_t)(const char *fmt, ...);
+
+extern pn532_debug_printf_t pn532_debug_printf;
+
+static inline void pn532_set_debug_printf(pn532_debug_printf_t func)
+{
+    pn532_debug_printf = func;
+}
 
 #ifdef DEBUG
-#define DMSG(args...)       Serial.print(args)
-#define DMSG_STR(str)       Serial.println(str)
-#define DMSG_HEX(num)       Serial.print(' '); Serial.print((num>>4)&0x0F, HEX); Serial.print(num&0x0F, HEX)
-#define DMSG_INT(num)       Serial.print(' '); Serial.print(num)
+#define DMSG(...)         do { if (pn532_debug_printf) pn532_debug_printf(__VA_ARGS__); } while (0)
+#define DMSG_STR(str)     do { if (pn532_debug_printf) pn532_debug_printf("%s\n", (str)); } while (0)
+#define DMSG_HEX(num)     do { if (pn532_debug_printf) pn532_debug_printf(" %02X", (uint8_t)(num)); } while (0)
+#define DMSG_INT(num)     do { if (pn532_debug_printf) pn532_debug_printf(" %d", (int)(num)); } while (0)
 #else
-#define DMSG(args...)
+#define DMSG(...)
 #define DMSG_STR(str)
 #define DMSG_HEX(num)
 #define DMSG_INT(num)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/PN532_I2C/PN532_I2C.cpp
+++ b/PN532_I2C/PN532_I2C.cpp
@@ -71,7 +71,7 @@ int8_t PN532_I2C::writeCommand(const uint8_t *header, uint8_t hlen, const uint8_
     
     _wire->endTransmission();
     
-    DMSG('\n');
+    DMSG_STR("\n");
 
     return readAckFrame();
 }
@@ -170,7 +170,7 @@ int16_t PN532_I2C::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
         
         DMSG_HEX(buf[i]);
     }
-    DMSG('\n');
+    DMSG_STR("\n");
     
     uint8_t checksum = read();
     if (0 != (uint8_t)(sum + checksum)) {
@@ -188,8 +188,8 @@ int8_t PN532_I2C::readAckFrame()
     uint8_t ackBuf[sizeof(PN532_ACK)];
     
     DMSG("wait for ack at : ");
-    DMSG(millis());
-    DMSG('\n');
+    DMSG_INT(millis());
+    DMSG_STR("\n");
     
     uint16_t time = 0;
     do {
@@ -208,8 +208,8 @@ int8_t PN532_I2C::readAckFrame()
     } while (1); 
     
     DMSG("ready at : ");
-    DMSG(millis());
-    DMSG('\n');
+    DMSG_INT(millis());
+    DMSG_STR("\n");
     
 
     for (uint8_t i = 0; i < sizeof(PN532_ACK); i++) {

--- a/PN532_SPI/PN532_SPI.cpp
+++ b/PN532_SPI/PN532_SPI.cpp
@@ -121,7 +121,7 @@ int16_t PN532_SPI::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
 
             DMSG_HEX(buf[i]);
         }
-        DMSG('\n');
+        DMSG_STR("\n");
 
         uint8_t checksum = read();
         if (0 != (uint8_t)(sum + checksum)) {
@@ -187,7 +187,7 @@ void PN532_SPI::writeFrame(const uint8_t *header, uint8_t hlen, const uint8_t *b
 
     digitalWrite(_ss, HIGH);
 
-    DMSG('\n');
+    DMSG_STR("\n");
 }
 
 int8_t PN532_SPI::readAckFrame()


### PR DESCRIPTION
## Summary
- add configurable debug printf function
- default to `printf`
- adapt PN532_I2C and PN532_SPI implementations for new macros

## Testing
- `gcc -c PN532/PN532_debug.c`


------
https://chatgpt.com/codex/tasks/task_e_6880522739608320a055b21b1ee999b2