### PR TITLE
Fix example to use lowercase PN532 API

### DIFF
--- a/PN532/PN532.c
+++ b/PN532/PN532.c
@@ -38,6 +38,17 @@ bool pn532_SAMConfig(pn532_t *nfc)
     return nfc->iface->read_response(nfc->iface,nfc->packet_buffer,8,1000) >= 0;
 }
 
+bool pn532_set_passive_activation_retries(pn532_t *nfc, uint8_t max_retries)
+{
+    uint8_t cmd[] = {PN532_COMMAND_RFCONFIGURATION, 5, 0xFF, 0x01, max_retries};
+    if(nfc->iface->write_command(nfc->iface, cmd, sizeof(cmd), NULL, 0))
+        return false;
+    return nfc->iface->read_response(nfc->iface,
+                                     nfc->packet_buffer,
+                                     sizeof(nfc->packet_buffer),
+                                     1000) >= 0;
+}
+
 bool pn532_read_passive_target_id(pn532_t *nfc, uint8_t cardbaudrate,
                                   uint8_t *uid, uint8_t *uid_length, uint16_t timeout)
 {

--- a/PN532/PN532.h
+++ b/PN532/PN532.h
@@ -9,6 +9,7 @@
 #define PN532_COMMAND_GETFIRMWAREVERSION    (0x02)
 #define PN532_COMMAND_SAMCONFIGURATION      (0x14)
 #define PN532_COMMAND_INLISTPASSIVETARGET   (0x4A)
+#define PN532_COMMAND_RFCONFIGURATION       (0x32)
 
 typedef struct {
     pn532_interface_t *iface;
@@ -21,6 +22,7 @@ void pn532_init(pn532_t *nfc, pn532_interface_t *iface);
 void pn532_begin(pn532_t *nfc);
 uint32_t pn532_get_firmware_version(pn532_t *nfc);
 bool pn532_SAMConfig(pn532_t *nfc);
+bool pn532_set_passive_activation_retries(pn532_t *nfc, uint8_t max_retries);
 bool pn532_read_passive_target_id(pn532_t *nfc, uint8_t cardbaudrate,
                                   uint8_t *uid, uint8_t *uid_length, uint16_t timeout);
 


### PR DESCRIPTION
## Summary
- expose `pn532_set_passive_activation_retries` in the C API
- switch `examples/blackpill/main.c` to the lowercase PN532 function names

## Testing
- `gcc -c PN532/PN532.c -o /tmp/pn.o`
- `gcc -c PN532_HSU/PN532_HSU.c -I. -I PN532 -o /tmp/hsu.o` *(fails: `stm32f1xx_hal.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68805715f5648320875ebeb8a97658b8