### PR TITLE
Use minimal C NDEF library

### DIFF
--- a/PN532/PN532.c
+++ b/PN532/PN532.c
@@ -67,20 +67,13 @@ bool pn532_read_passive_target_id(pn532_t *nfc, uint8_t cardbaudrate,
 
 void pn532_print_hex(const uint8_t *data, uint32_t numBytes)
 {
-    for(uint32_t i=0;i<numBytes;i++)
-    {
-#ifdef ARDUINO
-        Serial.print(" ");
-        if(data[i]<0x10) Serial.print("0");
-        Serial.print(data[i],HEX);
-#else
-        printf(" %02X",data[i]);
-#endif
+    for(uint32_t i = 0; i < numBytes; i++) {
+        if (pn532_debug_printf) {
+            pn532_debug_printf(" %02X", data[i]);
+        }
     }
-#ifdef ARDUINO
-    Serial.println();
-#else
-    printf("\n");
-#endif
+    if (pn532_debug_printf) {
+        pn532_debug_printf("\n");
+    }
 }
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It works with:
 ### Features
 + Support all interfaces of PN532 (I2C, SPI, HSU )
 + Read/write Mifare Classic Card
-+ Works with [Don's NDEF Library](http://goo.gl/jDjsXl)
++ Works with [Don's NDEF Library](http://goo.gl/jDjsXl) or the C implementation in `NDEF/c_version`
 + Support Peer to Peer communication(exchange data with android 4.0+)
 + Support [mbed platform](http://goo.gl/kGPovZ)
 
@@ -24,7 +24,8 @@ It works with:
 1. **Download [zip file](https://github.com/elechouse/PN532/archive/PN532_HSU.zip) and 
 extract the three folders(PN532, PN532_SPI, PN532_HSU and PN532_I2C) into libraries of Arduino.**
 2. Downlaod [Don's NDEF library](http://goo.gl/ewxeAe) and extract it into libraries of Arduino's into a new folder called "NDEF" (Note if you leave this folder as NDEF-Master Arduino will not be able to use it as a library)
-2. Follow the examples of the PN532 library
+2. Follow the examples of the PN532 library.  A minimal demonstration of the C
+   NDEF implementation is provided in `examples/ndef_c_example`.
 
 ### To do
 + Card emulation
@@ -80,3 +81,10 @@ framework.
 
 See [docs/STM32_HAL.md](docs/STM32_HAL.md) for example peripheral
 initialization and usage.
+
+## NDEF C version
+
+For bare-metal or STM32 targets without the Arduino framework the repository
+contains a minimal C implementation of NDEF message encoding.  Add
+`NDEF/c_version/ndef_c.c` to your project and include `ndef_c.h` to construct
+text records and encode NDEF messages.

--- a/examples/ndef_c_example/main.c
+++ b/examples/ndef_c_example/main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include "NDEF/c_version/ndef_c.h"
+
+int main(void)
+{
+    ndef_message_t msg;
+    ndef_message_init(&msg);
+    ndef_message_add_text_record(&msg, "Hello NFC");
+
+    uint8_t buffer[256];
+    uint16_t len = ndef_message_encode(&msg, buffer);
+
+    for(uint16_t i = 0; i < len; i++)
+        printf("%02X ", buffer[i]);
+    printf("\n");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- use debug printf in `pn532_print_hex`
- document the NDEF C implementation
- add `ndef_c` example showing text message encoding

## Testing
- `gcc -I. examples/ndef_c_example/main.c NDEF/c_version/ndef_c.c -o example && ./example`
- `gcc -c -I. PN532/PN532.c -o /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68805d06222c83209a1879a417d3a3df