### PR TITLE
Improve STM32 HAL documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,15 @@ If your Arduino has only one serial interface and you want to keep it for contro
 
 ## STM32 HAL
 
-The repository includes C implementations suitable for STM32Cube HAL in the
-`PN532_I2C`, `PN532_SPI` and `PN532_HSU` folders. When compiling for STM32 make
-sure only the `.c` files are added to your project. The Arduino `.cpp` versions
-should be removed or ignored during the build as they depend on the Arduino
-framework.
+The repository includes C implementations suitable for STM32Cube HAL.  Add
+`PN532/PN532.c`, `PN532/PN532_debug.c` and the interface driver you want from
+`PN532_I2C/PN532_I2C.c`, `PN532_SPI/PN532_SPI.c` or
+`PN532_HSU/PN532_HSU.c`.  When compiling for STM32 make sure only these `.c`
+files are used.  All Arduino specific `.cpp` sources should be removed or
+ignored so that there are no Arduino dependencies.
 
-See [docs/STM32_HAL.md](docs/STM32_HAL.md) for example peripheral
-initialization and usage.
+See [docs/STM32_HAL.md](docs/STM32_HAL.md) for peripheral initialisation and a
+minimal usage example.
 CubeIDE samples using the HAL drivers are provided in `examples/stm32_i2c` and `examples/stm32_spi`.
 
 ## NDEF C version

--- a/docs/STM32_HAL.md
+++ b/docs/STM32_HAL.md
@@ -1,15 +1,21 @@
 # Using the library with STM32 HAL
 
-The project contains C implementations for the PN532 interface which
-work with STM32Cube HAL.  These files are:
+This repository ships plain C implementations of the PN532 drivers so
+that they can be compiled in STM32Cube HAL projects without the Arduino
+framework.  Add the following source files to your application
+depending on the interface you plan to use:
 
-- `PN532_I2C/PN532_I2C.c`
-- `PN532_SPI/PN532_SPI.c`
-- `PN532_HSU/PN532_HSU.c`
+- `PN532/PN532.c`
+- `PN532/PN532_debug.c`
+- `PN532_I2C/PN532_I2C.c` *(I2C mode)*
+- `PN532_SPI/PN532_SPI.c` *(SPI mode)*
+- `PN532_HSU/PN532_HSU.c` *(UART/HSU mode)*
+- `NDEF/c_version/ndef_c.c` *(optional NDEF helpers)*
 
-When building for STM32 you should **exclude** all `.cpp` files located
-in the same folders.  They rely on the Arduino core and will produce
-errors if compiled for STM32.
+All C headers from these directories should be available on the include
+path.  Make sure that **none** of the `.cpp` files are compiled as they
+contain Arduino specific code and will pull in unnecessary
+dependencies.
 
 ## Peripheral initialization
 Below are minimal examples for setting up the HAL handles.  Adjust the
@@ -77,4 +83,12 @@ pn532_i2c_create_interface(&nfc_i2c, &iface);
 pn532_t nfc;
 pn532_init(&nfc, &iface);
 pn532_begin(&nfc);
+pn532_SAMConfig(&nfc);
+
+uint8_t uid[7];
+uint8_t uid_len;
+
+if (pn532_read_passive_target_id(&nfc, 0x00, uid, &uid_len, 1000)) {
+    // UID is now available in 'uid'
+}
 ```


### PR DESCRIPTION
## Summary
- clarify HAL installation instructions in README
- expand `docs/STM32_HAL.md` with required files, removal of Arduino deps and code snippet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880607314b083209d4efde72908c635