### PR TITLE
Define ISO14443A baud rate constant

### DIFF
--- a/PN532/PN532.h
+++ b/PN532/PN532.h
@@ -11,6 +11,9 @@
 #define PN532_COMMAND_INLISTPASSIVETARGET   (0x4A)
 #define PN532_COMMAND_RFCONFIGURATION       (0x32)
 
+// Card baud rates
+#define PN532_MIFARE_ISO14443A              (0x00)
+
 typedef struct {
     pn532_interface_t *iface;
     uint8_t uid[7];


### PR DESCRIPTION
## Summary
- add missing `PN532_MIFARE_ISO14443A` constant

## Testing
- `gcc -c examples/ndef_c_example/main.c -I. -I examples/ndef_c_example -I PN532 -I PN532_HSU -I PN532_I2C -I PN532_SPI -I PN532_SWHSU -I NDEF -I NDEF/c_version`
- `g++ /tmp/test.cpp -I. -I PN532 -c`

------
https://chatgpt.com/codex/tasks/task_e_688064a81e788320921ef78ee65bb33a