### PR TITLE
Add Modbus CRC helper for STM32 example

### DIFF
--- a/examples/blackpill/Makefile
+++ b/examples/blackpill/Makefile
@@ -1,0 +1,20 @@
+# Simple example Makefile for the BlackPill demo
+
+SRCS = main.c modbus_crc.c
+OBJS = $(SRCS:.c=.o)
+
+# Add paths for the PN532 library sources if they are available in your project
+# These are only placeholders and may need adjustment for your environment
+PN532_SRCS = ../../PN532/PN532.c \
+              ../../PN532/PN532_debug.c \
+              ../../PN532_HSU/PN532_HSU.c
+
+CFLAGS ?= -I. -I../../PN532 -I../../PN532_HSU
+
+all: blackpill.elf
+
+blackpill.elf: $(OBJS) $(PN532_SRCS)
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f $(OBJS) blackpill.elf

--- a/examples/blackpill/modbus_crc.c
+++ b/examples/blackpill/modbus_crc.c
@@ -1,0 +1,18 @@
+#include "modbus_crc.h"
+
+uint16_t ModbusCRC(const uint8_t *data, uint16_t length)
+{
+    uint16_t crc = 0xFFFF;
+    for (uint16_t i = 0; i < length; i++) {
+        crc ^= data[i];
+        for (uint8_t j = 0; j < 8; j++) {
+            if (crc & 0x0001) {
+                crc >>= 1;
+                crc ^= 0xA001;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    return crc;
+}

--- a/examples/blackpill/modbus_crc.h
+++ b/examples/blackpill/modbus_crc.h
@@ -1,0 +1,16 @@
+#ifndef MODBUS_CRC_H
+#define MODBUS_CRC_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint16_t ModbusCRC(const uint8_t *data, uint16_t length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MODBUS_CRC_H


### PR DESCRIPTION
## Summary
- implement Modbus RTU CRC16 helper
- add Makefile for blackpill example

## Testing
- `make -C examples/blackpill` *(fails: main.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68806d3acb8c8320a6a26965a9ca9337